### PR TITLE
#8 Fix for NPE on constructor factory 

### DIFF
--- a/src/main/java/com/nordstrom/automation/testng/ListenerChain.java
+++ b/src/main/java/com/nordstrom/automation/testng/ListenerChain.java
@@ -1,43 +1,14 @@
 package com.nordstrom.automation.testng;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.ServiceLoader;
-import java.util.Set;
-
-import org.testng.IAnnotationTransformer;
-import org.testng.IAnnotationTransformer2;
-import org.testng.IAnnotationTransformer3;
-import org.testng.IClassListener;
-import org.testng.IConfigurationListener;
-import org.testng.IConfigurationListener2;
-import org.testng.IInvokedMethod;
-import org.testng.IInvokedMethodListener;
-import org.testng.IInvokedMethodListener2;
-import org.testng.IMethodInstance;
-import org.testng.IMethodInterceptor;
-import org.testng.ISuite;
-import org.testng.ISuiteListener;
-import org.testng.ITestClass;
-import org.testng.ITestContext;
-import org.testng.ITestListener;
-import org.testng.ITestNGListener;
-import org.testng.ITestResult;
-import org.testng.annotations.IConfigurationAnnotation;
-import org.testng.annotations.IDataProviderAnnotation;
-import org.testng.annotations.IFactoryAnnotation;
-import org.testng.annotations.IListenersAnnotation;
-import org.testng.annotations.ITestAnnotation;
+import com.google.common.collect.Lists;
+import org.testng.*;
+import org.testng.annotations.*;
 import org.testng.internal.InvokedMethod;
 
-import com.google.common.collect.Lists;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.Optional;
 
 /**
  * This TestNG listener enables the addition of other listeners at runtime and guarantees the order in which they're
@@ -171,7 +142,10 @@ public class ListenerChain
      */
     @Override
     public void transform(IFactoryAnnotation annotation, Method method) {
-        attachListeners(method);
+        if(method != null)
+            attachListeners(method);
+        else
+            attachListeners(annotation.getDataProviderClass());
         
         synchronized(annotationXformers2) {
             for (IAnnotationTransformer2 annotationXformer : annotationXformers2) {

--- a/src/test/java/com/nordstrom/automation/testng/ConstructorFactory.java
+++ b/src/test/java/com/nordstrom/automation/testng/ConstructorFactory.java
@@ -1,0 +1,19 @@
+package com.nordstrom.automation.testng;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+public class ConstructorFactory {
+
+    public ConstructorFactory(){}
+
+    @DataProvider
+    public Object[] ints(){return new Object[]{1, 2, 3};}
+
+    @Factory(dataProvider = "ints", dataProviderClass = ConstructorFactory.class)
+    public ConstructorFactory(int i){ }
+
+    @Test
+    public void test(){}
+}

--- a/src/test/java/com/nordstrom/automation/testng/ListenerChainTest.java
+++ b/src/test/java/com/nordstrom/automation/testng/ListenerChainTest.java
@@ -1,16 +1,16 @@
 package com.nordstrom.automation.testng;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import org.testng.ITestNGListener;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.testng.ITestNGListener;
-import org.testng.TestListenerAdapter;
-import org.testng.TestNG;
-import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class ListenerChainTest {
 
@@ -330,6 +330,20 @@ public class ListenerChainTest {
         assertTrue(ChainedListener.testStarted.contains("testAfterSkipped"));
         assertTrue(ChainedListener.testSuccess.contains("testAfterSkipped"));
         
+    }
+
+    @Test
+    public void verifyConstructorFactory(){
+        ListenerChain lc = new ListenerChain();
+        TestListenerAdapter tla = new TestListenerAdapter();
+
+        TestNG testNG = new TestNG();
+        testNG.setTestClasses(new Class[]{ConstructorFactory.class});
+        testNG.addListener((ITestNGListener) lc);
+        testNG.addListener((ITestNGListener) tla);
+        testNG.run();
+
+        assertEquals(tla.getPassedTests().size(), 3, "Incorrect passed test count");
     }
     
 }


### PR DESCRIPTION
  Fixes #8 
  
However bacause at this point testng doesn't inject dataProviderClass property implicitly into IFactoryAnnotation annotation reference client needs to explicitly claim dataProivderClass inside @Factory annotation (even if data provider and factory are in the same class) like this: 
```
@Factory(dataProvider = "ints", dataProviderClass = ConstructorFactory.class)
```
For details please refer to this issue: https://github.com/cbeust/testng/issues/1631
  